### PR TITLE
adjusting bond_style and K parameters

### DIFF
--- a/examples/water/TIP3P.mol
+++ b/examples/water/TIP3P.mol
@@ -2,10 +2,10 @@ define LJ_H      as  0.0000 0.0000
 define LJ_O      as  0.1520 3.1507
 
 define bond_OH_l0 as 0.9572
-define bond_OH   as  553.00 $bond_OH_l0
+define bond_OH   as  harmonic 450.00 $bond_OH_l0
 
 define angle_HOH_theta0 as 104.52
-define angle_HOH as  100.00 $angle_HOH_theta0
+define angle_HOH as  harmonic 55.00 $angle_HOH_theta0
 
 define charge_H  as  0.417
 define charge_O  as -0.834


### PR DESCRIPTION
Original TIP3P article model is rigid, but LAMMPS recommends using bond_style harmonic and angle_style harmonic (or charmm) (for flexible water without fix shake)

References: 
http://lammps.sandia.gov/doc/Section_howto.html#howto-7
W. L. Jorgensen, J. Chandrasekhar, J. D. Madura, R. W. Impey, and M. L. Klein, J. Chem. Phys. 79, 926 (1983).