### PR TITLE
Update install.sh

### DIFF
--- a/highlight/install.sh
+++ b/highlight/install.sh
@@ -1,11 +1,41 @@
 #!/bin/bash
 source=$(cd $(dirname "$0"); pwd)/gtksourceview/playmol.lang
-destination=($(locate language-specs/def.lang | grep usr | sed 's/def.lang/playmol.lang/g'))
+
+destination=();
+while IFS= read -d $'\0' -r file ; do
+#  echo $file
+  if echo $file | grep -q usr; then
+    file=$(echo $file | grep usr | sed 's/def.lang/playmol.lang/g')
+#    echo $file
+    destination=("${destination[@]}" "$file");
+  fi
+done < <(locate -0 'language-specs/def.lang')
+
+n=${#destination[@]}
+
 if [ -z "$destination" ]; then
     echo "GtkSourceView was not found"
     exit
 fi
-command="$(which cp) -rf $source ${destination[0]}"
+
+if (( n > 1 )); then
+    echo
+    echo "[!] More than one GtkSourceView candidates found:"
+    echo
+    i=0
+    for option in ${destination[@]}; do
+      echo $i '=>' $option;
+      ((i++));
+    done
+    echo
+    echo "[?] Input integer corresponding to desired installation path"
+    echo
+    read j
+#    echo $j
+else
+    j=0
+fi
+
+command="$(which cp) -rf $source ${destination[$j]}"
 echo $command
 eval $command
-


### PR DESCRIPTION
more robust install.sh
asks for user input if unsure about the correct Gtk dir

references:
https://stackoverflow.com/questions/8213328/store-the-output-of-find-command-in-an-array
https://www.linuxjournal.com/content/bash-arrays
https://unix.stackexchange.com/questions/48535/can-grep-return-true-false-or-are-there-alternative-methods
https://stackoverflow.com/questions/10929453/read-a-file-line-by-line-assigning-the-value-to-a-variable
https://unix.stackexchange.com/questions/184863/what-is-the-meaning-of-ifs-n-in-bash-scripting
https://ryanstutorials.net/bash-scripting-tutorial/bash-input.php
https://askubuntu.com/questions/385528/how-to-increment-a-variable-in-bash
https://stackoverflow.com/questions/18668556/comparing-numbers-in-bash
https://stackoverflow.com/questions/16034749/if-elif-else-statement-issues-in-bash