### PR TITLE
removed m64 to build on 32 arch; playmol clean-all calls lib clean-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PREFIX ?= /usr/local
 
 # Compilers and their basic options:
 FORT ?= gfortran
-BASIC_F_OPTS = -march=native -m64 -cpp -fmax-errors=1 -Wunused
+BASIC_F_OPTS = -march=native -cpp -fmax-errors=1 -Wunused
 
 # Option FAST (default):
 FAST_F_OPTS = -Ofast
@@ -51,7 +51,7 @@ clean:
 
 clean-all:
 	rm -rf $(OBJDIR) $(BINDIR)
-	cd $(PACKMOL) && make clean
+	cd $(PACKMOL) && make clean-all
 
 install:
 	cp -f $(BINDIR)/* /usr/local/bin

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -6,7 +6,7 @@ all: packmol
 clean:
 	rm -f libpackmol.a
 
-cleanall:
+clean-all:
 	rm -rf packmol/
 	rm -f libpackmol.a
 


### PR DESCRIPTION
removed m64 to build correctly when on 32 arch, playmol clean-all now… calls lib clean-all